### PR TITLE
Fix: NoteOff event may not triggered

### DIFF
--- a/Midi.ahk
+++ b/Midi.ahk
@@ -414,7 +414,7 @@ __MidiInCallback( wParam, lParam, msg )
   data2     := (lParam >> 16) & 0xFF
 
   ; Determine the friendly name of the midi event based on the status byte
-  if ( highByte == 0x80 )
+  if ( highByte == 0x80 || ( highByte == 0x90 && data2 == 0 ) )
   {
     midiEvent.status := "NoteOff"
   }


### PR DESCRIPTION
The 0x90 event could not be received on my AHK, instead it triggered the 0x80 event with no velocity.
My keyboard is M-Audio KeyStation MINI32.